### PR TITLE
Fix a bug of updating Build#incremental_id

### DIFF
--- a/app/models/build.rb
+++ b/app/models/build.rb
@@ -75,7 +75,7 @@ class Build < ActiveRecord::Base
   end
 
   def update_incremental_id
-    update_attributes(incremental_id: job.builds_count)
+    update_attributes(incremental_id: job.builds.count)
   end
 
   private

--- a/spec/models/build_spec.rb
+++ b/spec/models/build_spec.rb
@@ -16,6 +16,7 @@ describe Build do
         build.started_at.should be_present
         build.finished_at.should be_present
         build.status.should == true
+        build.incremental_id.should_not be_nil
       end
     end
 
@@ -29,6 +30,7 @@ describe Build do
         build.started_at.should be_present
         build.finished_at.should be_present
         build.status.should == false
+        build.incremental_id.should_not be_nil
       end
     end
   end


### PR DESCRIPTION
`Build#incremental_id` should be 1 at first but nil actually now.
In this PR I fixed it.
