### PR TITLE
Build Worker のジョブが失敗したときに、Build オブジェクトを終了状態にする

### DIFF
--- a/app/workers/build_worker.rb
+++ b/app/workers/build_worker.rb
@@ -9,5 +9,11 @@ class BuildWorker
     def perform_async(id)
       Resque.enqueue(self, id)
     end
+
+    def on_failure(*args)
+      id = args[1]
+      message = args[0].message
+      Build.find(id).update_attributes!(finished_at: Time.now, output: message, status: false)
+    end
   end
 end


### PR DESCRIPTION
foremanでAltriaを起動していて、ジョブ実行中におもむろにforemanを終了させると(Ctrl+C)、
次回起動時にジョブが実行中のままになっていました。

実行中のままだと次のジョブを実行させることができないので、
Worker の`on_failure` ハンドラで対象のBuild オブジェクトを終了状態にさせるようにしました。

備考:
failure backend [ref](http://blog.kyanny.me/entry/2012/11/22/003056) を使った解決法も考えましたが、この仕組みはfailure時の後処理というよりも、ストレージへの格納やIRCやメールへの通知に使うためのものだと思い、使いませんでした。
