### PR TITLE
Set build output and status before after executes

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -114,7 +114,9 @@ class Job < ActiveRecord::Base
   end
 
   def execute_script
-    Altria::Executer.execute(script)
+    result = Altria::Executer.execute(script)
+    current_build.update_attributes!(output: result[:output], status: result[:status])
+    result
   end
 
   def execute_before_enqueues

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -115,6 +115,7 @@ class Job < ActiveRecord::Base
 
   def execute_script
     result = Altria::Executer.execute(script)
+    return unless result
     current_build.update_attributes!(output: result[:output], status: result[:status])
     result
   end

--- a/spec/factories/build.rb
+++ b/spec/factories/build.rb
@@ -3,7 +3,5 @@ require "factory_girl"
 FactoryGirl.define do
   factory(:build) do
     job { FactoryGirl.create(:job) }
-    started_at { Time.now }
-    finished_at { Time.now }
   end
 end

--- a/spec/requests/builds_spec.rb
+++ b/spec/requests/builds_spec.rb
@@ -14,7 +14,7 @@ describe "Builds" do
   end
 
   let(:build) do
-    FactoryGirl.create(:build, job: job)
+    FactoryGirl.create(:build, job: job, finished_at: Time.now)
   end
 
   describe "GET /jobs/:job_id/builds" do
@@ -31,7 +31,7 @@ describe "Builds" do
     context "with page" do
       before do
         params[:page] = 2
-        10.times { FactoryGirl.create(:build, job: job) }
+        10.times { FactoryGirl.create(:build, job: job, finished_at: Time.now) }
       end
 
       it "paginates builds" do


### PR DESCRIPTION
I'm making altria-ikachan plugin now.

I'd like to change the message depending on the result of the build like this.
https://github.com/mizzy/altria-ikachan/blob/master/lib/altria/ikachan/notifier.rb#L18

So I'd like to set build.status attribute after job#execute_script.

Please check this pull request.

Thanks.
